### PR TITLE
[12251] [myenergi] Added support for director.myenergi.net (get hostname via this host)

### DIFF
--- a/bundles/org.openhab.binding.myenergi/pom.xml
+++ b/bundles/org.openhab.binding.myenergi/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.openhab.addons.bundles</groupId>
     <artifactId>org.openhab.addons.reactor.bundles</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.binding.myenergi</artifactId>

--- a/bundles/org.openhab.binding.myenergi/src/main/java/org/openhab/binding/myenergi/internal/MyEnergiApiClient.java
+++ b/bundles/org.openhab.binding.myenergi/src/main/java/org/openhab/binding/myenergi/internal/MyEnergiApiClient.java
@@ -93,12 +93,12 @@ public class MyEnergiApiClient {
     /**
      * Sets the credentials (username/password) to be used for API calls.
      *
-     * @param username the username to be used.
-     * @param password the password to be used.
+     * @param hubSerialNumber the serial number of the myenergi hub
+     * @param password the password for this hub in the myenergi mobile app.
      * @throws MyEnergiApiException
      */
-    public void initialize(final String username, final String password) throws ApiException {
-        this.username = username;
+    public void initialize(final String hubSerialNumber, final String password) throws ApiException {
+        this.username = hubSerialNumber;
         this.password = password;
         HttpClientFactory factory = httpClientFactory;
         if (factory == null) {
@@ -113,17 +113,17 @@ public class MyEnergiApiClient {
             AuthenticationStore auth = client.getAuthenticationStore();
             auth.clearAuthentications();
             auth.clearAuthenticationResults();
-            if (host.equals("")) {
-                host = "s" + username.charAt(username.length() - 1) + ".myenergi.net";
+            if ("".equals(host)) {
+                host = new MyEnergiGetHostFromDirector().getHostName(client, hubSerialNumber);
             }
             try {
                 URL baseURL = new URL("https", host, "/");
                 logger.debug("API base URL: {}", baseURL.toString());
 
                 client.getAuthenticationStore().addAuthentication(
-                        new DigestAuthentication(baseURL.toURI(), Authentication.ANY_REALM, username, password));
+                        new DigestAuthentication(baseURL.toURI(), Authentication.ANY_REALM, hubSerialNumber, password));
                 this.baseURL = baseURL;
-                logger.debug("Digest authentication added: {}", username);
+                logger.debug("Digest authentication added: {}", hubSerialNumber);
                 if (!client.isStarted()) {
                     client.start();
                 }

--- a/bundles/org.openhab.binding.myenergi/src/main/java/org/openhab/binding/myenergi/internal/MyEnergiGetHostFromDirector.java
+++ b/bundles/org.openhab.binding.myenergi/src/main/java/org/openhab/binding/myenergi/internal/MyEnergiGetHostFromDirector.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.myenergi.internal;
+
+import java.net.URL;
+
+import javax.validation.constraints.NotNull;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.Authentication;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.util.DigestAuthentication;
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpMethod;
+import org.openhab.binding.myenergi.internal.exception.ApiException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link MyEnergiGetHostFromDirector} is a helper class to get the hostname on
+ * myenergi.net for the the myenergi API.
+ * It finds the server for a given hub serial number
+ *
+ * @author Volkmar Nissen - Initial contribution
+ */
+@NonNullByDefault
+public class MyEnergiGetHostFromDirector {
+    private static final int SLEEP_BEFORE_REINIT_MS = 3000;
+    public static final String MY_ENERGI_RESPONSE_FIELD = "X_MYENERGI-asn";
+
+    private final Logger logger = LoggerFactory.getLogger(MyEnergiGetHostFromDirector.class);
+
+    /**
+     * Finds the server for a given hub serial number
+     *
+     * @param httpClientFactory the client to be used.
+     * @throws ApiException
+     */
+
+    public String getHostName(@NotNull HttpClient httpClient, @NotNull String hubSerialNumber) throws ApiException {
+        String directorHostname = "director.myenergi.net";
+        try {
+            URL directorURL = new URL("https", directorHostname, "/");
+            // No password is needed at director.myenergie.net
+            httpClient.getAuthenticationStore().addAuthentication(
+                    new DigestAuthentication(directorURL.toURI(), Authentication.ANY_REALM, hubSerialNumber, ""));
+            int lastResponseStatus = 0;
+            String lastResponseReason = "";
+            int outerLoop = 0;
+            while (outerLoop < 3) {
+                outerLoop++;
+                try {
+                    int innerLoop = 0;
+                    while ((innerLoop < 2)) {
+                        innerLoop++;
+                        if (!httpClient.isStarted()) {
+                            httpClient.start();
+                        }
+
+                        Request request = httpClient.newRequest(directorURL.toString()).method(HttpMethod.GET);
+
+                        logger.info("sending API request attempt# {}: {}", innerLoop, directorURL.toString());
+
+                        ContentResponse response = request.send();
+                        String hostname = response.getHeaders().get(MY_ENERGI_RESPONSE_FIELD);
+                        if (null != hostname) {
+                            return hostname;
+                        }
+
+                        logger.debug("HTTP response code: {}, reason: {}", lastResponseStatus, lastResponseReason);
+                        if (logger.isTraceEnabled()) {
+                            for (HttpField field : response.getHeaders()) {
+                                logger.trace("HTTP header: {}", field.toString());
+                            }
+                        }
+                    }
+                    logger.info("Re-initializing Api missing host name in response header");
+                } catch (Exception e) {
+                    logger.info("Re-initializing Api connection after exception caught", e);
+                }
+                // reset connection and try again
+                Thread.sleep(SLEEP_BEFORE_REINIT_MS);
+            }
+            throw new ApiException("Director returned no host name after several attempts");
+        } catch (Exception e) {
+            throw new ApiException("Exception caught during API execution", e);
+        }
+    }
+}

--- a/bundles/org.openhab.binding.myenergi/src/main/java/org/openhab/binding/myenergi/internal/util/ZappiBoostMode.java
+++ b/bundles/org.openhab.binding.myenergi/src/main/java/org/openhab/binding/myenergi/internal/util/ZappiBoostMode.java
@@ -12,12 +12,15 @@
  */
 package org.openhab.binding.myenergi.internal.util;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link ZappiBoostMode} enumeration is used to model the various Zappi boost charging modes.
  *
  * @author Rene Scherer - Initial contribution
  *
  */
+@NonNullByDefault
 public enum ZappiBoostMode {
     // stops the current boost cycle
     STOP(2),

--- a/bundles/org.openhab.binding.myenergi/src/main/java/org/openhab/binding/myenergi/internal/util/ZappiChargingMode.java
+++ b/bundles/org.openhab.binding.myenergi/src/main/java/org/openhab/binding/myenergi/internal/util/ZappiChargingMode.java
@@ -12,12 +12,15 @@
  */
 package org.openhab.binding.myenergi.internal.util;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link ZappiChargingMode} enumeration is used to model the various Zappi charging modes.
  *
  * @author Rene Scherer - Initial contribution
  *
  */
+@NonNullByDefault
 public enum ZappiChargingMode {
     BOOST(0),
     FAST(1),

--- a/bundles/org.openhab.binding.myenergi/src/test/java/org/openhab/binding/myenergi/internal/MyEnergiApiClientTest.java
+++ b/bundles/org.openhab.binding.myenergi/src/test/java/org/openhab/binding/myenergi/internal/MyEnergiApiClientTest.java
@@ -25,6 +25,7 @@ import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.HttpContentResponse;
 import org.eclipse.jetty.client.HttpRequest;
 import org.eclipse.jetty.client.api.AuthenticationStore;
+import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.BeforeAll;
@@ -76,6 +77,7 @@ class MyEnergiApiClientTest {
     private static final int ZAPPI_SERIAL_NUMBER = 21287642;
 
     private static MyEnergiApiClient api = new MyEnergiApiClient();
+    private static HttpFields responseFields = mock(HttpFields.class);
 
     private static AuthenticationStore authenticationStore = mock(AuthenticationStore.class);
     private static HttpClientFactory httpClientFactory = mock(HttpClientFactoryMock.class);
@@ -90,12 +92,15 @@ class MyEnergiApiClientTest {
         when(httpClient.getAuthenticationStore()).thenReturn(authenticationStore);
         when(httpClient.newRequest(anyString())).thenReturn(request);
         when(httpClient.isStarted()).thenReturn(true);
+        // doNothing().when(httpClient).stop();
+
         when(request.method(HttpMethod.GET)).thenReturn(request);
 
         when(request.send()).thenReturn(response);
         when(response.getStatus()).thenReturn(RESPONSE_200_STATUS);
         when(response.getReason()).thenReturn(RESPONSE_200_REASON);
-
+        when(responseFields.get(MyEnergiGetHostFromDirector.MY_ENERGI_RESPONSE_FIELD)).thenReturn("SomeHost");
+        when(response.getHeaders()).thenReturn(responseFields);
         api.setHttpClientFactory(httpClientFactory);
         api.initialize(TEST_USERNAME, TEST_PASSWORD_VALID);
     }

--- a/bundles/org.openhab.binding.myenergi/src/test/java/org/openhab/binding/myenergi/internal/MyEnergiGetHostFromDirectorTest.java
+++ b/bundles/org.openhab.binding.myenergi/src/test/java/org/openhab/binding/myenergi/internal/MyEnergiGetHostFromDirectorTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.myenergi.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.io.net.http.HttpClientFactory;
+
+/**
+ * The {@link MyEnergiGetHostFromDirectorTest} is a test class for {@link MyEnergiGetHostFromDirector}.
+ *
+ * @author Volkmar Nissen - Initial contribution
+ */
+@NonNullByDefault
+class MyEnergiGetHostFromDirectorTest {
+
+    class HttpClientFactoryForTest implements HttpClientFactory {
+
+        @Override
+        public HttpClient createHttpClient(String consumerName) {
+            SslContextFactory.Client sslContextFactory = new SslContextFactory.Client();
+            sslContextFactory.setTrustAll(true); // you might want to think about this first
+            return new HttpClient(sslContextFactory);
+        }
+
+        @Override
+        public HttpClient getCommonHttpClient() {
+            // TODO Auto-generated method stub
+            return new HttpClient();
+        }
+    }
+
+    /**
+     * There is no password check at director.myenergi.net. So, the password can be left empty.
+     * Only the hub serial number must be an existing one. May be this changes in the future.
+     * This test uses Internet URL to director.myenergi.net. The access is not mocked
+     *
+     * @throws Exception
+     */
+    @Test
+    void testGetHostName() throws Exception {
+        HttpClient client = new HttpClientFactoryForTest()
+                .createHttpClient(MyEnergiGetHostFromDirectorTest.class.getSimpleName());
+        try {
+
+            client.start();
+            String hostName = new MyEnergiGetHostFromDirector().getHostName(client, "12215753");
+            Assertions.assertTrue(hostName.contains("myenergi"));
+        } catch (Exception e) {
+            Assertions.fail("Exception caught" + e.getMessage());
+        } finally {
+            client.stop();
+        }
+    }
+}


### PR DESCRIPTION

Cleaned up some codestyle warnings.
Migrated maven version number to 3.2.0-SNAPSHOT

[myenergi][WIP]
Since a while, myenergi.net changed the determination of the hostname for the api server.
This PR adds a class which takes this into account. It uses the algoritm described at https://github.com/twonk/MyEnergi-App-Api. So, this is a bugfix. There were nearly no discussions in openhab forum. I added issue 12251 for it.

A test class was also added. It uses Internet connection to myenergi.net. 
I cleaned up some codestyle warnings.
Migrated maven version number to 3.2.0-SNAPSHOT

I don't think that a direct build is available for your github account. So, testing is only possible by build/compile the code.



Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
